### PR TITLE
DRAFT RFC: easier prompt API: more intuitive return type; system exit upon keyboard interrupt (by default) - DO NOT MERGE

### DIFF
--- a/InquirerLib/InquirerPy/resolver.py
+++ b/InquirerLib/InquirerPy/resolver.py
@@ -16,6 +16,8 @@ from InquirerLib.InquirerPy.prompts.number import NumberPrompt
 from InquirerLib.InquirerPy.prompts.rawlist import RawlistPrompt
 from InquirerLib.InquirerPy.prompts.secret import SecretPrompt
 from InquirerLib.InquirerPy.utils import (
+    ResultKey,
+    ResultValue,
     InquirerPyKeybindings,
     InquirerPyQuestions,
     InquirerPySessionResult,
@@ -128,10 +130,11 @@ def prompt(
     questions: InquirerPyQuestions,
     style: Optional[Dict[str, str]] = None,
     vi_mode: bool = False,
-    raise_keyboard_interrupt: bool = True,
+    raise_keyboard_interrupt: bool = False,
     keybindings: Optional[InquirerPyKeybindings] = None,
     style_override: bool = True,
-) -> InquirerPySessionResult:
+    raise_system_exit: bool = True,  # almost equivalent to calling sys.exit()
+) -> Dict[ResultKey, ResultValue]:
     """Classic syntax entrypoint to create a prompt session.
 
     Resolve user provided list of questions, display prompts and get the results.
@@ -206,7 +209,7 @@ def prompt(
                 "message": message,
                 "style": question_style,
                 "vi_mode": vi_mode,
-                "raise_keyboard_interrupt": raise_keyboard_interrupt,
+                "raise_keyboard_interrupt": raise_keyboard_interrupt | raise_system_exit,
                 "session_result": result,
                 "keybindings": {**keybindings, **question.pop("keybindings", {})},
             }
@@ -215,5 +218,10 @@ def prompt(
             ).execute()
         except KeyError:
             raise RequiredKeyNotFound
+        except KeyboardInterrupt:
+            if raise_system_exit:
+                raise SystemExit from None
+            else:
+                raise
 
     return result

--- a/InquirerLib/InquirerPy/utils.py
+++ b/InquirerLib/InquirerPy/utils.py
@@ -54,7 +54,9 @@ class InquirerPyStyle(NamedTuple):
     dict: Dict[str, str]
 
 
-InquirerPySessionResult = Dict[Union[str, int], Optional[Union[str, bool, List[Any]]]]
+ResultKey = Union[str, int]
+ResultValue = Union[str, bool, List[Any]]
+InquirerPySessionResult = Dict[ResultKey, ResultValue]
 InquirerPyChoice = Union[List[Any], List["Choice"], List[Dict[str, Any]]]
 InquirerPyListChoices = Union[
     Callable[["InquirerPySessionResult"], InquirerPyChoice],


### PR DESCRIPTION
This kind of easier API could help me with some work projects. This is NOT TESTED & EXPECTED TO FAIL the existing unit-test suite. The purpose is to give as clear justification as possible for a BREAKING CHANGE planned for the prompt API.