### PR TITLE
prompt API updates - BREAKING CHANGES

### DIFF
--- a/InquirerLib/InquirerPy/resolver.py
+++ b/InquirerLib/InquirerPy/resolver.py
@@ -83,6 +83,7 @@ def _get_question(
 
 async def prompt_async(
     questions: InquirerPyQuestions,
+    *,
     style: Optional[Dict[str, str]] = None,
     vi_mode: bool = False,
     raise_keyboard_interrupt: bool = True,
@@ -126,6 +127,7 @@ async def prompt_async(
 
 def prompt(
     questions: InquirerPyQuestions,
+    *,
     style: Optional[Dict[str, str]] = None,
     vi_mode: bool = False,
     raise_keyboard_interrupt: bool = True,
@@ -141,7 +143,7 @@ def prompt(
         style: A :class:`dict` containing the style specification for the prompt. Refer to :ref:`pages/style:Style` for more info.
         vi_mode: Use vim keybindings for the prompt instead of the default emacs keybindings.
             Refer to :ref:`pages/kb:Keybindings` for more info.
-        raise_keyboard_interrupt: Raise the :class:`KeyboardInterrupt` exception when `ctrl-c` is pressed. If false, the result
+        raise_keyboard_interrupt: [DEPRECATED & SUBJECT TO CHANGE] Raise the :class:`KeyboardInterrupt` exception when `ctrl-c` is pressed. If false, the result
             will be `None` and the question is skipped.
         keybindings: List of custom :ref:`pages/kb:Keybindings` to apply. Refer to documentation for more info.
         style_override: Override all default styles. When providing any style customisation, all default styles are removed when this is True.

--- a/README.md
+++ b/README.md
@@ -48,7 +48,9 @@ python >= 3.7
 
 Some functions are exported directly using `from InquirerLib`; other functions and all exported objects are within `InquirerLib.InquirerPy` namespace.
 
-**[Documentation for InquirerPy](https://inquirerpy.readthedocs.io/)** applies with these updated imports.
+The optional arguments for `prompt` and `prompt_async` are now keyword arguments, with `raise_keyboard_interrupt` (which defaults to `True`) now deprecated. Rationale is to support a possible easier prompt API in the future - see DRAFT RFC PR: <https://github.com/brodybits/InquirerLib/pull/3>
+
+**[Documentation for InquirerPy](https://inquirerpy.readthedocs.io/)** applies with these updated imports and optional arguments for `prompt` and `prompt_async` as now keyword arguments.
 
 Note that importing from `InquirerLib.InquirerPy.inquirer` is DEPRECATED, as documented below.
 


### PR DESCRIPTION
- optional arguments now as keyword arguments
- document `raise_keyboard_interrupt` as DEPRECATED & SUBJECT TO CHANGE

__RATIONALE (updated):__

- The keyboard interrupt handling configuration and handling may need to be changed to support an easier API, with a prototype shown in:
  - https://github.com/brodybits/InquirerLib/pull/3
- Make it ieaser to select a more limited number of options

TODO:

- [x] update documentation in README.md _(these changes will show up in readthedocs once this is working)_

__ADDITIONAL REMARKS:__

I noticed that this update did not break any existing test cases. It looks like `prompt` options are tested using keyword arguments anyways. I also noticed that `prompt_async` is not tested with any options, think this needs improvement in the future.